### PR TITLE
[FIX] Error on repmat method

### DIFF
--- a/Example/ClustMapExample.R
+++ b/Example/ClustMapExample.R
@@ -32,7 +32,7 @@ X <- matrix(0,D,N);
 for(k in 1:K){
   i <- (Z==k);
   M <- sum(i);
-  X[,i] <- sqrtm(Sigma[,,k])%*%matrix(rnorm(D*M),D)+repmat(Mu[,k],1,M);
+  X[,i] <- sqrtm(Sigma[,,k])%*%matrix(rnorm(D*M),D)+kronecker(matrix(1,1,M), Mu[,k]);
 }
 i <- sample(1:N,N,replace=FALSE);
 Z <- Z[i];


### PR DESCRIPTION
The _repmat_ method did not work properly. In _clustMapDP.R_ you overwrite the method using:

```

#' Replicates the behaviour of the repmat function of MATLAB
#' @param a The matrix to copy
#' @param n The n value for tiling
#' @param m The m value for the tiling
#' @export
#repmat <- function(a,n,m) {kronecker(matrix(1,n,m),a)}
repmat <- function(a,n,m) {kronecker(matrix(1,n,m),a)}
```

But you didn't do here, since _repmat_ method exist in R package _pracma_ https://www.rdocumentation.org/packages/pracma/versions/1.9.9/topics/repmat and doesn't have the same behavour that you expect, it is prefereble to use _kronecker_